### PR TITLE
Increase clickTab JQuery Selector Specificity

### DIFF
--- a/src/icn3dui/simple_ui.js
+++ b/src/icn3dui/simple_ui.js
@@ -514,13 +514,13 @@ iCn3DUI.prototype = {
     },
 
     clickTab: function() { var me = this;
-        $('.icn3d-bottomTab').click(function (e) {
-           var height = $(".icn3d-insideTab").height();
+        $("#" + me.pre + "toolbox > .icn3d-bottomTab").click(function (e) {
+           var height = $("#" + me.pre + "toolbox > .icn3d-insideTab").height();
            if(height === 0) {
-                $(".icn3d-insideTab").height(260);
+                $("#" + me.pre + "toolbox > .icn3d-insideTab").height(260);
            }
            else {
-             $(".icn3d-insideTab").height(0);
+             $("#" + me.pre + "toolbox > .icn3d-insideTab").height(0);
            }
         });
     },


### PR DESCRIPTION
For multiple molecules, the lack of JQuery Selector specificity meant that these multiple instances were interfering with each other. This makes it so that the clickTab event only affects the molecule it is related to.

This also prevents the click listener from being applied repeatedly when multiple molecules are loaded again due to the previous lack of selector specificity.